### PR TITLE
tests: cobertura para áreas hoje suprimidas pelos baselines PHPStan

### DIFF
--- a/tests/Certificate/Asn1Test.php
+++ b/tests/Certificate/Asn1Test.php
@@ -14,4 +14,31 @@ class Asn1Test extends \PHPUnit\Framework\TestCase
         $actual = Asn1::getCNPJ(file_get_contents(__DIR__ . self::TEST_PUBLIC_KEY));
         $this->assertEquals($expected, $actual);
     }
+
+    public function testGetCNPJReturnsNullWhenOidNotPresent()
+    {
+        $key = file_get_contents(__DIR__ . '/../fixtures/certs/e-CPF_pubkey.pem');
+        $this->assertNull(Asn1::getCNPJ($key));
+    }
+
+    public function testGetCPF()
+    {
+        $key = file_get_contents(__DIR__ . '/../fixtures/certs/e-CPF_pubkey.pem');
+        $this->assertSame('80767940130', Asn1::getCPF($key));
+    }
+
+    public function testGetCPFReturnsNullWhenOidNotPresent()
+    {
+        $key = file_get_contents(__DIR__ . self::TEST_PUBLIC_KEY);
+        $this->assertNull(Asn1::getCPF($key));
+    }
+
+    public function testGetOIDdataReturnsEmptyWhenNotFound()
+    {
+        // OID inválido garante que o marker não é encontrado
+        $this->assertSame(
+            '',
+            Asn1::getOIDdata('1.2.3.4.5.6.7.8.9', file_get_contents(__DIR__ . self::TEST_PUBLIC_KEY))
+        );
+    }
 }

--- a/tests/Exception/ExceptionFactoriesTest.php
+++ b/tests/Exception/ExceptionFactoriesTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace NFePHP\Common\Tests\Exception;
+
+use NFePHP\Common\Exception\CertificateException;
+use NFePHP\Common\Exception\ExceptionInterface;
+use NFePHP\Common\Exception\SignerException;
+use NFePHP\Common\Exception\SoapException;
+use NFePHP\Common\Exception\ValidatorException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Cobre as fábricas estáticas das exceções que usam "new static()". O objetivo é
+ * garantir que cada método continua devolvendo uma instância concreta da própria
+ * exceção (preservando o contrato ao migrar de `new static` para configuração
+ * @phpstan-consistent-constructor).
+ */
+class ExceptionFactoriesTest extends TestCase
+{
+    public function testCertificateExceptionFactories()
+    {
+        foreach (
+            [
+                CertificateException::unableToRead(),
+                CertificateException::unableToOpen(),
+                CertificateException::signContent(),
+                CertificateException::getPrivateKey(),
+                CertificateException::signatureFailed(),
+            ] as $exception
+        ) {
+            $this->assertInstanceOf(CertificateException::class, $exception);
+            $this->assertInstanceOf(ExceptionInterface::class, $exception);
+            $this->assertNotSame('', $exception->getMessage());
+        }
+    }
+
+    public function testSignerExceptionFactories()
+    {
+        $cases = [
+            SignerException::isNotXml(),
+            SignerException::digestComparisonFailed(),
+            SignerException::signatureComparisonFailed(),
+            SignerException::tagNotFound('infNFe'),
+        ];
+        foreach ($cases as $exception) {
+            $this->assertInstanceOf(SignerException::class, $exception);
+            $this->assertInstanceOf(ExceptionInterface::class, $exception);
+        }
+        $this->assertStringContainsString('infNFe', $cases[3]->getMessage());
+    }
+
+    public function testSoapExceptionFactories()
+    {
+        $unableCurl = SoapException::unableToLoadCurl('detalhe');
+        $this->assertInstanceOf(SoapException::class, $unableCurl);
+        $this->assertStringContainsString('detalhe', $unableCurl->getMessage());
+
+        $fault = SoapException::soapFault('falhou', 42);
+        $this->assertInstanceOf(SoapException::class, $fault);
+        $this->assertSame(42, $fault->getCode());
+        $this->assertStringContainsString('falhou', $fault->getMessage());
+    }
+
+    public function testValidatorExceptionFactories()
+    {
+        $xmlErrors = ValidatorException::xmlErrors(['erro 1', 'erro 2']);
+        $this->assertInstanceOf(ValidatorException::class, $xmlErrors);
+        $this->assertStringContainsString('erro 1', $xmlErrors->getMessage());
+        $this->assertStringContainsString('erro 2', $xmlErrors->getMessage());
+
+        $notXml = ValidatorException::isNotXml();
+        $this->assertInstanceOf(ValidatorException::class, $notXml);
+    }
+}

--- a/tests/Soap/SoapBaseTest.php
+++ b/tests/Soap/SoapBaseTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace NFePHP\Common\Tests\Soap;
+
+use NFePHP\Common\Certificate;
+use NFePHP\Common\Files;
+use NFePHP\Common\Soap\SoapBase;
+use NFePHP\Common\Soap\SoapFake;
+use NFePHP\Common\Soap\SoapInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+class SoapBaseTest extends TestCase
+{
+    const TEST_PFX_FILE = '/../fixtures/certs/certificado_teste.pfx';
+
+    /**
+     * setAccessible(true) é obrigatório no PHP 7.4–8.0 para acesso a membros
+     * não públicos via Reflection. A partir do 8.1 não tem efeito, e no 8.5 emite
+     * E_DEPRECATED. Encapsulamos com supressão para manter compatibilidade.
+     *
+     * @param ReflectionMethod|ReflectionProperty $member
+     */
+    private function reflectionMakeAccessible($member): void
+    {
+        @$member->setAccessible(true);
+    }
+
+    private function newSoap(): SoapFake
+    {
+        return new SoapFake();
+    }
+
+    /**
+     * uid() é usado para compor o caminho do diretório temporário ("/sped-{uid}/").
+     * O contrato é devolver um valor convertível para string não vazia.
+     */
+    public function testUidReturnsStringableNonEmptyValue()
+    {
+        $soap = $this->newSoap();
+        $method = new ReflectionMethod(SoapBase::class, 'uid');
+        $this->reflectionMakeAccessible($method);
+        $uid = $method->invoke($soap);
+        $this->assertNotSame('', (string) $uid);
+    }
+
+    /**
+     * randomName() deve devolver uma string com o formato esperado pelo cURL/SoapClient
+     * (subdiretório certs/ + nome aleatório + .pem).
+     */
+    public function testRandomNameReturnsValidPemFileName()
+    {
+        $soap = $this->newSoap();
+        $reflection = new ReflectionClass(SoapBase::class);
+
+        $certsDir = $reflection->getProperty('certsdir');
+        $this->reflectionMakeAccessible($certsDir);
+        $certsDir->setValue($soap, 'certs/');
+
+        $filesystem = $reflection->getProperty('filesystem');
+        $this->reflectionMakeAccessible($filesystem);
+        $filesystem->setValue($soap, new Files(sys_get_temp_dir() . '/sped-common-test-' . uniqid() . '/'));
+
+        $method = $reflection->getMethod('randomName');
+        $this->reflectionMakeAccessible($method);
+        $name = $method->invoke($soap);
+        $this->assertIsString($name);
+        $this->assertStringStartsWith('certs/', $name);
+        $this->assertStringEndsWith('.pem', $name);
+    }
+
+    /**
+     * removeTemporarilyFiles() não pode lançar erro quando ainda não há
+     * filesystem ou certsdir configurados (estado inicial do objeto).
+     */
+    public function testRemoveTemporarilyFilesDoesNothingOnFreshInstance()
+    {
+        $soap = $this->newSoap();
+        $soap->removeTemporarilyFiles();
+        $this->assertInstanceOf(SoapBase::class, $soap);
+    }
+
+    /**
+     * Ciclo completo de gravação/remoção de arquivos temporários: exercita
+     * saveTemporarilyKeyFiles() -> removeTemporarilyFiles() (que internamente
+     * chama listContents() do filesystem local).
+     */
+    public function testSaveAndRemoveTemporarilyKeyFiles()
+    {
+        $certificate = Certificate::readPfx(
+            file_get_contents(__DIR__ . self::TEST_PFX_FILE),
+            'associacao'
+        );
+        $soap = new SoapFake();
+        $soap->disableCertValidation(true);
+        $soap->loadCertificate($certificate);
+        $folder = sys_get_temp_dir() . '/sped-common-test-' . uniqid() . '/';
+        $soap->setTemporaryFolder($folder);
+
+        $soap->saveTemporarilyKeyFiles();
+
+        $reflection = new ReflectionClass(SoapBase::class);
+        $certsdir = $reflection->getProperty('certsdir');
+        $this->reflectionMakeAccessible($certsdir);
+        $this->assertSame('certs/', $certsdir->getValue($soap));
+
+        $prifile = $reflection->getProperty('prifile');
+        $this->reflectionMakeAccessible($prifile);
+        $priPath = $folder . $prifile->getValue($soap);
+        $this->assertFileExists($priPath);
+
+        $soap->removeTemporarilyFiles();
+        $this->assertFileDoesNotExist($priPath);
+    }
+
+    /**
+     * O parâmetro $soapheader em send() deve ser compatível entre interface,
+     * classe abstrata e implementações concretas (default null, tipo opcional
+     * SoapHeader). Garante essa compatibilidade via reflexão.
+     */
+    public function testSendSignatureCompatibility()
+    {
+        foreach ([SoapInterface::class, SoapBase::class, SoapFake::class] as $class) {
+            $params = (new ReflectionMethod($class, 'send'))->getParameters();
+            $this->assertSame('soapheader', $params[7]->getName(), "Em $class");
+            $this->assertTrue($params[7]->isOptional(), "Em $class soapheader deve ser opcional");
+            $this->assertNull($params[7]->getDefaultValue(), "Em $class default deve ser null");
+        }
+    }
+}

--- a/tests/Tags/MakeBaseTest.php
+++ b/tests/Tags/MakeBaseTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace NFePHP\Common\Tests\Tags;
+
+use NFePHP\Common\Tags\MakeBase;
+use NFePHP\Common\Tags\Tag;
+use NFePHP\Common\Tags\TagInterface;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * Stub mínimo de Tag para verificar o comportamento de MakeBase.
+ */
+class FakeStdTag extends Tag implements TagInterface
+{
+    /**
+     * @var \stdClass
+     */
+    public $std;
+
+    public function __construct($dom = null)
+    {
+        parent::__construct($dom);
+        $this->std = new stdClass();
+    }
+
+    public function loadParameters(\stdClass $std)
+    {
+        $this->std = $std;
+    }
+
+    public function toNode()
+    {
+        return $this->dom->createElement('fake');
+    }
+}
+
+class FakeMake extends MakeBase
+{
+    protected $rootname = 'NFe';
+    protected $xmlns = 'http://www.portalfiscal.inf.br/nfe';
+
+    protected $available = [
+        'tagide' => ['class' => FakeStdTag::class, 'type' => 'single'],
+        'tagemit' => ['class' => FakeStdTag::class, 'type' => 'single'],
+        'taginfnfe' => ['class' => FakeStdTag::class, 'type' => 'single'],
+    ];
+
+    public function parse()
+    {
+    }
+}
+
+class MakeBaseTest extends TestCase
+{
+    public function testCallStoresSingleProperty()
+    {
+        $make = new FakeMake();
+        $std = new stdClass();
+        $std->cuf = '35';
+        $result = $make->tagide($std);
+        $this->assertInstanceOf(FakeStdTag::class, $result);
+        $this->assertInstanceOf(FakeStdTag::class, $make->ide);
+        $this->assertSame('35', $make->ide->std->cuf);
+    }
+
+    public function testCallThrowsWhenMethodNotAvailable()
+    {
+        $make = new FakeMake();
+        $std = new stdClass();
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches('/Não encontrada referencia ao método/');
+        $make->tagunknown($std);
+    }
+
+    public function testSetToAsciiPropagatesToStdArgument()
+    {
+        $make = new FakeMake();
+        $make->setToAscii(true);
+        $std = new stdClass();
+        $std->cuf = '35';
+        $make->tagide($std);
+        // __call grava onlyAscii no próprio std passado
+        $this->assertTrue($std->onlyAscii);
+    }
+
+    public function testCreatePropertyAssignsTag()
+    {
+        $make = new FakeMake();
+        $tag = new FakeStdTag();
+        $make->createProperty('foo', $tag);
+        $this->assertSame($tag, $make->foo);
+    }
+
+    public function testSetToAscii()
+    {
+        $make = new FakeMake();
+        $this->assertFalse($make->setToAscii());
+        $this->assertTrue($make->setToAscii(true));
+        $this->assertFalse($make->setToAscii(false));
+    }
+}


### PR DESCRIPTION
## Sumário

Acrescenta testes automatizados que capturam o comportamento atual das
áreas cujos erros estão listados em \`phpstan-baseline*.neon\`. O objetivo
é ter uma rede de segurança **antes** de aplicar correções no código
(src/) — as alterações em src/ virão em um PR seguinte.

Todos os novos testes passam no estado atual do projeto (não dependem
de nenhuma alteração em src/).

### Áreas cobertas

- **\`tests/Certificate/Asn1Test\`** — \`getCNPJ\`/\`getCPF\`/\`getOIDdata\`
  em chaves presentes e ausentes do certificado.
- **\`tests/Soap/SoapBaseTest\`** — \`uid()\`, \`randomName()\`,
  \`saveTemporarilyKeyFiles\` e o ciclo de gravação/remoção dos arquivos
  temporários (que internamente exercita \`listContents\`); também a
  compatibilidade da assinatura de \`send()\` entre interface, classe
  abstrata e \`SoapFake\`.
- **\`tests/Tags/MakeBaseTest\`** — \`__call\` para tags do tipo
  \`single\`, \`createProperty\`, \`setToAscii\` e propagação ao \`std\`,
  além das exceções esperadas.
- **\`tests/Exception/ExceptionFactoriesTest\`** — fábricas estáticas
  de \`CertificateException\`, \`SignerException\`, \`SoapException\` e
  \`ValidatorException\`.

## Test plan

- [x] \`composer test\` — 106 testes / 183 asserções, todos verdes.
- [x] Sem alterações em \`src/\`, então PHPStan/PHPCS seguem com o
  comportamento atual da master.

## Próximos passos

Em sequência será aberto outro PR com as correções em \`src/\` que zeram
boa parte dos baselines. Esse PR de código incluirá também os testes de
caminhos que hoje têm bug (ex.: \`MakeBase::__call\` do tipo \`multiple\`,
\`checkIdKey\`/\`\$infId\`, \`SoapClientExtended\` que sequer carrega no
PHP 8.5), pois esses testes só fazem sentido junto com o fix.